### PR TITLE
Fix graphml parsing (NumberFormatException)

### DIFF
--- a/src/org/graphstream/stream/file/FileSourceXML.java
+++ b/src/org/graphstream/stream/file/FileSourceXML.java
@@ -460,7 +460,7 @@ public abstract class FileSourceXML extends SourceBase implements FileSource, XM
 			e = getNextEvent();
 
 			while (e.getEventType() == XMLEvent.CHARACTERS) {
-				buffer.append(e.asCharacters());
+				buffer.append(e.asCharacters().getData());
 				e = getNextEvent();
 			}
 


### PR DESCRIPTION
Fix NumberFormatException when reading characters. Pass getData() instead of the Characters event.
See #363